### PR TITLE
Fix build with Qt 5.11_beta3 (dropping qt5_use_modules)

### DIFF
--- a/src/downloads/qml/CMakeLists.txt
+++ b/src/downloads/qml/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(${TARGET} SHARED
 	${plugin_HDRS}
 )
 
-qt5_use_modules(${TARGET} Core Qml Quick)
+target_link_libraries(${TARGET} Qt5::Core Qt5::Qml Qt5::Quick)
 
 target_link_libraries(${TARGET}
 	${GLOG_LIBRARIES}

--- a/src/downloads/qml/CMakeLists.txt
+++ b/src/downloads/qml/CMakeLists.txt
@@ -30,6 +30,9 @@ add_library(${TARGET} SHARED
 	${plugin_HDRS}
 )
 
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Qml REQUIRED)
+find_package(Qt5Quick REQUIRED)
 target_link_libraries(${TARGET} Qt5::Core Qt5::Qml Qt5::Quick)
 
 target_link_libraries(${TARGET}


### PR DESCRIPTION
Closes #4 

Tested on Arch GNU/Linux. Build log: [ubuntu-download-manager.log](https://github.com/ubports/ubuntu-download-manager/files/2049894/ubuntu-download-manager.log)

Not sure if Qt5Core is even needed, it builds fine without it