### PR TITLE
test_network_error_transition: make QStateMachine a pointer

### DIFF
--- a/tests/downloads/daemon/test_network_error_transition.cpp
+++ b/tests/downloads/daemon/test_network_error_transition.cpp
@@ -27,24 +27,24 @@ TestNetworkErrorTransition::init() {
     _down = new MockSMFileDownload();
     _s1 = new QState();
     _s2 = new QFinalState();
+    _stateMachine = new QStateMachine();
 
-    _stateMachine.addState(_s1);
-    _stateMachine.addState(_s2);
+    _stateMachine->addState(_s1);
+    _stateMachine->addState(_s2);
 
     _transition = new NetworkErrorTransition(_down, _s1, _s2);
     _s1->addTransition(_transition);
-    _stateMachine.setInitialState(_s1);
+    _stateMachine->setInitialState(_s1);
 }
 
 void
 TestNetworkErrorTransition::cleanup() {
     BaseTestCase::cleanup();
-    _stateMachine.removeState(_s1);
-    _stateMachine.removeState(_s2);
     delete _transition;
     delete _down;
     delete _s1;
     delete _s2;
+    delete _stateMachine;
 }
 
 void
@@ -104,14 +104,14 @@ TestNetworkErrorTransition::testOnTransition_data() {
 
 void
 TestNetworkErrorTransition::testOnTransition() {
-    SignalBarrier startedSpy(&_stateMachine, SIGNAL(started()));
-    SignalBarrier finishedSpy(&_stateMachine, SIGNAL(finished()));
+    SignalBarrier startedSpy(_stateMachine, SIGNAL(started()));
+    SignalBarrier finishedSpy(_stateMachine, SIGNAL(finished()));
     QFETCH(QNetworkReply::NetworkError, code);
 
     EXPECT_CALL(*_down, emitNetworkError(code))
         .Times(1);
 
-    _stateMachine.start();
+    _stateMachine->start();
 
     // ensure that we started
     QVERIFY(startedSpy.ensureSignalEmitted());

--- a/tests/downloads/daemon/test_network_error_transition.h
+++ b/tests/downloads/daemon/test_network_error_transition.h
@@ -42,7 +42,7 @@ class TestNetworkErrorTransition : public BaseTestCase {
     void testOnTransition();
 
  private:
-    QStateMachine _stateMachine;
+    QStateMachine* _stateMachine;
     MockSMFileDownload* _down;
     NetworkErrorTransition* _transition;
     QState* _s1;


### PR DESCRIPTION
There seems to be something persisting over multiple runs of the tests,
crashing it. Work around this by not reusing the QStateMachine object
but creating a new one for each run.