### PR TITLE
Fix unimplemented slot

### DIFF
--- a/src/downloads/qml/ubuntu_download_manager.cpp
+++ b/src/downloads/qml/ubuntu_download_manager.cpp
@@ -153,6 +153,11 @@ void UbuntuDownloadManager::downloadGroupCreated(GroupDownload* group)
     Q_UNUSED(group);
 }
 
+void UbuntuDownloadManager::downloadsFound(DownloadsList* downloads)
+{
+    Q_UNUSED(downloads);
+}
+
 void UbuntuDownloadManager::registerError(DownloadError& downloadError)
 {
     m_errorMessage = downloadError.message();


### PR DESCRIPTION
Fixes the error:
```
Error relocating /usr/lib/qt5/qml/Ubuntu/DownloadManager/libUbuntuDownloadManager.so: _ZN6Ubuntu15DownloadManager21UbuntuDownloadManager14downloadsFoundEPNS0_13DownloadsListE: symbol not found
```