### PR TITLE
Fix deprecation warning with Qt 5.15

### DIFF
--- a/src/common/public/ubuntu/transfers/metadata.cpp
+++ b/src/common/public/ubuntu/transfers/metadata.cpp
@@ -214,7 +214,7 @@ Metadata::custom() const {
         if (key.startsWith(CUSTOM_PREFIX)) {
             QString customKey = key;
             customKey.replace(CUSTOM_PREFIX, "");
-            custom.insert(customKey, values(key)[0]);
+            custom.insert(customKey, value(key));
         }
     }
     return custom;


### PR DESCRIPTION
The function "QList<T> QMap::values(const Key &key) const" is meant for
special maps that contain multiple values per key which isn't the case
here. Replace it with a simple "value" call.

Fixes #25